### PR TITLE
Drop SLSA GitHub generator support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,9 @@ jobs:
       group: "release"
       cancel-in-progress: false
     permissions:
-      id-token: write    # Required for SLSA provenance
+      id-token: write    # Required for signed tags
       contents: write    # Required for release and tag creation
       pull-requests: write # Required for bumpr commenting
-      actions: read      # Required for SLSA generator
       attestations: write # Required for build provenance attestation
     uses: actionutils/trusted-tag-releaser/.github/workflows/trusted-release-workflow.yml@v0
     secrets:

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -1,6 +1,6 @@
 name: Trusted Go Release Workflow
 
-# This workflow creates a SLSA-compliant release for GitHub repositories
+# This workflow creates a secure release for GitHub repositories
 # It's designed as a reusable workflow that can be called from other workflows
 # It enforces releases only through labeled PRs (bump:patch, bump:minor, bump:major)
 on:
@@ -85,7 +85,6 @@ jobs:
       id-token: write # needed for keyless signing
       attestations: write # needed for provenance
     outputs:
-      base64-subjects: ${{ steps.binary.outputs.base64-subjects }}
       artifacts: ${{ steps.goreleaser.outputs.artifacts }}
     steps:
       - uses: actions/checkout@v4
@@ -105,14 +104,6 @@ jobs:
           args: release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate binary hashes
-        id: binary
-        env:
-          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
-        run: |
-          set -euo pipefail
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "base64-subjects=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
       - uses: actions/attest-build-provenance@v2
         with:
           subject-checksums: ./dist/checksums.txt
@@ -121,23 +112,8 @@ jobs:
         with:
           subject-path: ./dist/checksums.txt
 
-  # Generate SLSA provenance using reusable workflow
-  generate-provenance:
-    needs: [version, goreleaser]
-    if: needs.version.outputs.tag_name != ''
-    permissions:
-      id-token: write    # Required for SLSA provenance generation
-      contents: write    # Required for attestations
-      actions: read      # Required to access workflow information
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    with:
-      base64-subjects: ${{ needs.goreleaser.outputs.base64-subjects }}
-      upload-assets: true
-      upload-tag-name: ${{ needs.version.outputs.tag_name }}
-      draft-release: true
-
   release:
-    needs: [version, generate-provenance]
+    needs: [version, goreleaser]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
@@ -165,44 +141,9 @@ jobs:
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
           echo "Release URL: $RELEASE_URL"
 
-  verification-with-slsa-verifier:
-    needs: [version, release, goreleaser, generate-provenance]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Install the verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.7.0
-
-      - name: Download assets
-        env:
-          PROVENANCE: ${{ needs.generate-provenance.outputs.provenance-name }}
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ needs.version.outputs.tag_name }}
-        run: |
-          set -euo pipefail
-          gh -R "$GITHUB_REPOSITORY" release download "$TAG_NAME" -p "*.tar.gz"
-          gh -R "$GITHUB_REPOSITORY" release download "$TAG_NAME" -p "*.zip"
-          gh -R "$GITHUB_REPOSITORY" release download "$TAG_NAME" -p "*.sbom.json"
-          gh -R "$GITHUB_REPOSITORY" release download "$TAG_NAME" -p "$PROVENANCE"
-      - name: Verify assets
-        env:
-          CHECKSUMS: ${{ needs.goreleaser.outputs.base64-subjects }}
-          PROVENANCE: ${{ needs.generate-provenance.outputs.provenance-name }}
-        run: |
-          set -euo pipefail
-          checksums=$(echo "$CHECKSUMS" | base64 -d)
-          while read -r line; do
-              fn=$(echo $line | cut -d ' ' -f2)
-              echo "Verifying $fn"
-              slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
-                                            --source-uri "github.com/$GITHUB_REPOSITORY" \
-                                            "$fn"
-          done <<<"$checksums"
-
   # https://goreleaser.com/install/#verifying-the-artifacts
   verification-with-cosign:
-    needs: [version, release, goreleaser, generate-provenance]
+    needs: [version, release, goreleaser]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Remove slsa-framework/slsa-github-generator dependency
- Simplify workflow while maintaining security through GitHub's native attestation
- Fix workflow failures caused by SLSA generator issues

## Changes
- Remove generate-provenance job using slsa-github-generator
- Remove verification-with-slsa-verifier job  
- Update job dependencies to remove generate-provenance references
- Clean up SLSA-specific permissions and comments
- Keep GitHub native attestation (actions/attest-build-provenance) for build provenance

## Test plan
- [ ] Verify workflow runs successfully without SLSA generator
- [ ] Confirm attestations are still generated via GitHub's native feature
- [ ] Test release process works end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)