### PR TITLE
Add binstaller support for generating install scripts

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -86,6 +86,7 @@ jobs:
       attestations: write # needed for provenance
     outputs:
       artifacts: ${{ steps.goreleaser.outputs.artifacts }}
+      checksum_file: ${{ steps.checksumtxt.outputs.checksum_file }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,16 +105,77 @@ jobs:
           args: release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get checksum file name
+        id: checksumtxt
+        env:
+          ARTIFACTS: ${{ steps.goreleaser.outputs.artifacts }}
+        run: |
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .name')
+          echo "checksum file: ${checksum_file}"
+          echo "checksum_file=${checksum_file}" >> $GITHUB_OUTPUT
       - uses: actions/attest-build-provenance@v2
         with:
-          subject-checksums: ./dist/checksums.txt
-      # Generate attestations for checksum.txt file itself.
+          subject-checksums: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
+      # Generate attestations for checksum file itself.
       - uses: actions/attest-build-provenance@v2
         with:
-          subject-path: ./dist/checksums.txt
+          subject-path: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
+
+  binstaller:
+    needs: [version, goreleaser]
+    if: needs.version.outputs.tag_name != ''
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed for keyless signing
+      attestations: write # needed for provenance
+    outputs:
+      artifacts: ${{ steps.goreleaser.outputs.artifacts }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Check for binstaller config
+        id: check-config
+        run: |
+          if [[ -f .config/binstaller.yml || -f .config/binstaller.yaml ]]; then
+            echo "config_exists=true" >> $GITHUB_OUTPUT
+            echo "Binstaller config found"
+          else
+            echo "config_exists=false" >> $GITHUB_OUTPUT
+            echo "No binstaller config found, skipping binstaller steps"
+          fi
+      - uses: actionutils/trusted-tag-verifier@v0
+        if: steps.check-config.outputs.config_exists == 'true'
+        with:
+          verify: 'binary-install/setup-x@v1'
+      - name: Install binstaller
+        if: steps.check-config.outputs.config_exists == 'true'
+        uses: binary-install/setup-x@v1
+        with:
+          script_url: https://raw.githubusercontent.com/binary-install/binstaller/main/install.sh
+          gh_attestations_verify_flags: --repo binary-install/binstaller --cert-identity=.github/workflows/generate-installer.yml@refs/heads/main
+      - name: Embed checksums
+        if: steps.check-config.outputs.config_exists == 'true'
+        env:
+          checksum_file: ${{ needs.goreleaser.outputs.checksum_file }}
+        run: binst embed-checksums --mode=checksum-file --file=./dist/${checksum_file} --version='${{ needs.version.outputs.tag_name }}'
+      - name: Generate installer
+        if: steps.check-config.outputs.config_exists == 'true'
+        run: binst gen --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
+      - name: Upload installer to release
+        if: steps.check-config.outputs.config_exists == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload '${{ needs.version.outputs.tag_name }}' ./dist/install.sh
+      - name: Attest installer
+        if: steps.check-config.outputs.config_exists == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ./dist/install.sh
 
   release:
-    needs: [version, goreleaser]
+    needs: [version, goreleaser, binstaller]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
@@ -158,18 +220,9 @@ jobs:
         run: |
           gh -R "$GITHUB_REPOSITORY" release download "$TAG_NAME"
 
-      - name: Get checksum file name
-        id: checksumtxt
-        env:
-          ARTIFACTS: ${{ needs.goreleaser.outputs.artifacts }}
-        run: |
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .name')
-          echo "checksum file: ${checksum_file}"
-          echo "checksum_file=${checksum_file}" >> $GITHUB_OUTPUT
-
       - name: Verify checksum signature
         env:
-          checksum_file: ${{ steps.checksumtxt.outputs.checksum_file }}
+          checksum_file: ${{ needs.goreleaser.outputs.checksum_file }}
         run: |
           cosign verify-blob \
             --certificate-identity-regexp '^https://github.com/' \
@@ -180,6 +233,6 @@ jobs:
 
       - name: Verify checksum
         env:
-          checksum_file: ${{ steps.checksumtxt.outputs.checksum_file }}
+          checksum_file: ${{ needs.goreleaser.outputs.checksum_file }}
         run: |
           sha256sum --ignore-missing -c "${checksum_file}"


### PR DESCRIPTION
## Summary
- Add binstaller job to generate install.sh script for releases
- Automatically check for binstaller config and skip if not present
- Upload generated installer to GitHub releases with attestation

## Changes
- Added `binstaller` job that conditionally runs based on config file existence
- Integrated with trusted tag verifier for security
- Added installer generation, upload, and attestation steps
- Refactored checksum file handling to use dynamic filenames instead of hardcoded paths

## Test plan
- [ ] Test with repository that has `.config/binstaller.yml`
- [ ] Test with repository that doesn't have binstaller config (should skip cleanly)
- [ ] Verify install script is uploaded to release
- [ ] Verify attestation is created for install script

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new installer generation step that runs conditionally and attaches an installer script to releases when applicable.

* **Chores**
  * Improved handling of checksum files in the release process for greater reliability and consistency.
  * Enhanced workflow dependencies to ensure correct execution order and artifact usage across release steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->