### PR TITLE
Fix binstaller job to access ./dist directory

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -120,20 +120,8 @@ jobs:
       - uses: actions/attest-build-provenance@v2
         with:
           subject-path: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
-
-  binstaller:
-    needs: [version, goreleaser]
-    if: needs.version.outputs.tag_name != ''
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # needed for keyless signing
-      attestations: write # needed for provenance
-    outputs:
-      artifacts: ${{ steps.goreleaser.outputs.artifacts }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
+      
+      # Binstaller steps
       - name: Check for binstaller config
         id: check-config
         run: |
@@ -157,7 +145,7 @@ jobs:
       - name: Embed checksums
         if: steps.check-config.outputs.config_exists == 'true'
         env:
-          checksum_file: ${{ needs.goreleaser.outputs.checksum_file }}
+          checksum_file: ${{ steps.checksumtxt.outputs.checksum_file }}
         run: binst embed-checksums --mode=checksum-file --file=./dist/${checksum_file} --version='${{ needs.version.outputs.tag_name }}' --config=.config/binstaller.yml
       - name: Generate installer
         if: steps.check-config.outputs.config_exists == 'true'
@@ -175,7 +163,7 @@ jobs:
           subject-path: ./dist/install.sh
 
   release:
-    needs: [version, goreleaser, binstaller]
+    needs: [version, goreleaser]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Move binstaller steps from separate job into goreleaser job
- Ensures binstaller has access to the ./dist directory created by goreleaser
- Fixes issue where binstaller couldn't access distribution files

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Confirm binstaller can access ./dist files
- [ ] Check that installer generation works properly

🤖 Generated with [Claude Code](https://claude.ai/code)