### PR TITLE
feat: add runner script generation to trusted release workflow

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Generate installer and runner scripts
         if: steps.check-config.outputs.config_exists == 'true'
         run: |
-          binst gen --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
+          binst gen --type=installer --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
           binst gen --type=runner --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/run.sh
       - name: Upload installer and runner to release
         if: steps.check-config.outputs.config_exists == 'true'

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -116,6 +116,9 @@ jobs:
       - uses: actions/attest-build-provenance@v3
         with:
           subject-checksums: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
+      # Generate attestations for checksum file itself.
+      - uses: actions/attest-build-provenance@v3
+        with:
           subject-path: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
 
       # Binstaller steps

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -113,12 +113,9 @@ jobs:
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .name')
           echo "checksum file: ${checksum_file}"
           echo "checksum_file=${checksum_file}" >> $GITHUB_OUTPUT
-      - uses: actions/attest-build-provenance@v2
+      - uses: actions/attest-build-provenance@v3
         with:
           subject-checksums: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
-      # Generate attestations for checksum file itself.
-      - uses: actions/attest-build-provenance@v2
-        with:
           subject-path: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
 
       # Binstaller steps
@@ -159,16 +156,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload '${{ needs.version.outputs.tag_name }}' ./dist/install.sh ./dist/run.sh
-      - name: Attest installer
+      - name: Attest binstaller scripts
         if: steps.check-config.outputs.config_exists == 'true'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
-          subject-path: ./dist/install.sh
-      - name: Attest runner script
-        if: steps.check-config.outputs.config_exists == 'true'
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: ./dist/run.sh
+          subject-path: |
+            ./dist/install.sh
+            ./dist/run.sh
 
   release:
     needs: [version, goreleaser]

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -147,12 +147,11 @@ jobs:
         env:
           checksum_file: ${{ steps.checksumtxt.outputs.checksum_file }}
         run: binst embed-checksums --mode=checksum-file --file=./dist/${checksum_file} --version='${{ needs.version.outputs.tag_name }}'
-      - name: Generate installer
+      - name: Generate installer and runner scripts
         if: steps.check-config.outputs.config_exists == 'true'
-        run: binst gen --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
-      - name: Generate runner script
-        if: steps.check-config.outputs.config_exists == 'true'
-        run: binst gen --type=runner --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/run.sh
+        run: |
+          binst gen --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
+          binst gen --type=runner --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/run.sh
       - name: Upload installer and runner to release
         if: steps.check-config.outputs.config_exists == 'true'
         env:

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/attest-build-provenance@v2
         with:
           subject-path: ./dist/${{ steps.checksumtxt.outputs.checksum_file }}
-      
+
       # Binstaller steps
       - name: Check for binstaller config
         id: check-config
@@ -150,17 +150,25 @@ jobs:
       - name: Generate installer
         if: steps.check-config.outputs.config_exists == 'true'
         run: binst gen --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/install.sh
-      - name: Upload installer to release
+      - name: Generate runner script
+        if: steps.check-config.outputs.config_exists == 'true'
+        run: binst gen --type=runner --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/run.sh
+      - name: Upload installer and runner to release
         if: steps.check-config.outputs.config_exists == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload '${{ needs.version.outputs.tag_name }}' ./dist/install.sh
+          gh release upload '${{ needs.version.outputs.tag_name }}' ./dist/install.sh ./dist/run.sh
       - name: Attest installer
         if: steps.check-config.outputs.config_exists == 'true'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ./dist/install.sh
+      - name: Attest runner script
+        if: steps.check-config.outputs.config_exists == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ./dist/run.sh
 
   release:
     needs: [version, goreleaser]


### PR DESCRIPTION
## Summary

- Add generation of runner scripts (run.sh) alongside installer scripts using binstaller
- Consolidate build provenance attestations to improve workflow efficiency
- Update to actions/attest-build-provenance@v3

## Changes

- **Runner Script Generation**: Added step to generate runner scripts using `binst gen --type=runner`
- **Upload Enhancement**: Modified upload step to include both installer and runner scripts
- **Attestation Optimization**: Consolidated multiple attestations where possible while respecting API constraints
- **Version Updates**: Updated attestation action to v3

## Test plan

- [x] Verify workflow runs successfully with binstaller configuration
- [x] Confirm both install.sh and run.sh are generated and uploaded to releases  
- [x] Validate build provenance attestations are created correctly
- [x] Test runner script functionality (runs binary without installation)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now include both a downloadable runner script and the installer.

* **Chores**
  * Release packaging now uploads installer and runner assets.
  * Automated generation of installer and runner during the release process.
  * Supply-chain attestations upgraded to the latest version and expanded to cover multiple release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->