### PR TITLE
fix: skip e2e tests for fork PRs and add workflow_dispatch support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,9 @@ permissions:
 
 jobs:
   test:
-    # Skip for fork PRs when triggered by pull_request event
+    # Skip for fork PRs when triggered by pull_request event (no access to secrets)
+    # For fork PRs, use workflow_dispatch with the fork's commit SHA to test manually
+    # GitHub allows referencing commits from forks using @SHA in workflow references
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,13 +33,34 @@ jobs:
 
       - name: Set environment variables based on event type
         id: vars
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # For manual triggers
-            PR_NUMBER="${{ github.event.inputs.pr_number || 'manual' }}"
-            SHA="${{ github.event.inputs.sha || github.sha }}"
-            HEAD_REF="${{ github.ref_name }}"
-            PR_URL="Manual trigger from branch: ${{ github.ref_name }}"
+            if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+              PR_NUMBER="${{ github.event.inputs.pr_number }}"
+
+              # If SHA not provided, fetch from PR
+              if [ -z "${{ github.event.inputs.sha }}" ]; then
+                echo "Fetching PR #${PR_NUMBER} information..."
+                PR_INFO=$(gh pr view ${PR_NUMBER} --repo ${{ github.repository }} --json headRefOid,headRefName,url)
+                SHA=$(echo "$PR_INFO" | jq -r '.headRefOid')
+                HEAD_REF=$(echo "$PR_INFO" | jq -r '.headRefName')
+                PR_URL=$(echo "$PR_INFO" | jq -r '.url')
+                echo "Fetched SHA: $SHA"
+              else
+                SHA="${{ github.event.inputs.sha }}"
+                HEAD_REF="${{ github.ref_name }}"
+                PR_URL="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+              fi
+            else
+              # No PR number provided
+              PR_NUMBER="manual"
+              SHA="${{ github.event.inputs.sha || github.sha }}"
+              HEAD_REF="${{ github.ref_name }}"
+              PR_URL="Manual trigger from branch: ${{ github.ref_name }}"
+            fi
           else
             # For pull_request events
             PR_NUMBER="${{ github.event.pull_request.number }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,12 +2,26 @@ name: E2E Test
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to test (optional)'
+        required: false
+        type: string
+      sha:
+        description: 'Commit SHA to test (optional, defaults to current branch)'
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   test:
+    # Skip for fork PRs when triggered by pull_request event
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -15,72 +29,105 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Set environment variables based on event type
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # For manual triggers
+            PR_NUMBER="${{ github.event.inputs.pr_number || 'manual' }}"
+            SHA="${{ github.event.inputs.sha || github.sha }}"
+            HEAD_REF="${{ github.ref_name }}"
+            PR_URL="Manual trigger from branch: ${{ github.ref_name }}"
+          else
+            # For pull_request events
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            SHA="${{ github.event.pull_request.head.sha }}"
+            HEAD_REF="${{ github.event.pull_request.head.ref }}"
+            PR_URL="${{ github.event.pull_request.html_url }}"
+          fi
+
+          # Set outputs for use in other steps
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "sha_short=$(echo $SHA | cut -c1-8)" >> $GITHUB_OUTPUT
+
       - name: Checkout test repository
         uses: actions/checkout@v5
         with:
           repository: actionutils/test-trusted-go-releaser
           token: ${{ secrets.TEST_TRUSTED_GO_RELEASER_REPO_GITHUB_TOKEN }}
 
-      - name: Create test base branch
+      - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Create test base branch name with release-test prefix
-          COMMIT_SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)
-          TEST_BASE_BRANCH="release-test-base-pr-${{ github.event.pull_request.number }}-$COMMIT_SHORT_SHA"
+      - name: Create test base branch
+        env:
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
+          SHA: ${{ steps.vars.outputs.sha }}
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          # Create test base branch name
+          TEST_BASE_BRANCH="release-test-base-pr-${PR_NUMBER}-${SHA_SHORT}"
           echo "TEST_BASE_BRANCH=$TEST_BASE_BRANCH" >> $GITHUB_ENV
 
-          # Create base branch from main with sed changes
+          # Create and checkout new branch
           git checkout -b "$TEST_BASE_BRANCH"
 
-          # Update release.yml to use the PR commit hash instead of @main
-          sed -i 's|actionutils/trusted-go-releaser/\.github/workflows/\([^@]*\)@main|actionutils/trusted-go-releaser/.github/workflows/\1@${{ github.event.pull_request.head.sha }}|g' .github/workflows/release.yml
+          # Update workflow to use the PR commit
+          sed -i "s|actionutils/trusted-go-releaser/\.github/workflows/\([^@]*\)@main|actionutils/trusted-go-releaser/.github/workflows/\1@${SHA}|g" .github/workflows/release.yml
 
+          # Commit and push changes
           git add .github/workflows/release.yml
-          git commit -m "chore: update workflow refs to use PR commit ${{ github.event.pull_request.head.sha }}"
-
+          git commit -m "chore: update workflow refs to use PR commit ${SHA}"
           git push origin "$TEST_BASE_BRANCH"
 
       - name: Create feature branch
         env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
+          HEAD_REF: ${{ steps.vars.outputs.head_ref }}
         run: |
-          # Create feature branch name
-          FEATURE_BRANCH="test-feature-pr-${{ github.event.pull_request.number }}-$(date +%s)"
+          # Create feature branch name with timestamp
+          FEATURE_BRANCH="test-feature-pr-${PR_NUMBER}-$(date +%s)"
           echo "FEATURE_BRANCH=$FEATURE_BRANCH" >> $GITHUB_ENV
 
-          # Create feature branch from the test base branch
+          # Create and checkout feature branch
           git checkout -b "$FEATURE_BRANCH"
 
-          # Make a minimal change to trigger a release
-          echo "# Test change for PR #${{ github.event.pull_request.number }}" >> README.md
-          echo "Test commit from trusted-go-releaser PR #${{ github.event.pull_request.number }}" >> test-file.txt
+          # Make test changes
+          echo "# Test change for PR #${PR_NUMBER}" >> README.md
+          echo "Test commit from trusted-go-releaser PR #${PR_NUMBER}" >> test-file.txt
 
+          # Commit and push
           git add .
-          git commit -m "test: trigger release for trusted-go-releaser PR #${{ github.event.pull_request.number }}
+          git commit -m "test: trigger release for trusted-go-releaser PR #${PR_NUMBER}
 
           This is a test commit to validate the trusted-go-releaser workflow
-          using ref: $PR_HEAD_REF"
+          using ref: ${HEAD_REF}"
 
           git push origin "$FEATURE_BRANCH"
 
       - name: Create PR with bump:patch label
         env:
           GH_TOKEN: ${{ secrets.TEST_TRUSTED_GO_RELEASER_REPO_GITHUB_TOKEN }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
+          SHA: ${{ steps.vars.outputs.sha }}
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+          HEAD_REF: ${{ steps.vars.outputs.head_ref }}
+          PR_URL: ${{ steps.vars.outputs.pr_url }}
         run: |
-          # Get commit short hash for title
-          COMMIT_SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)
-
+          # Create pull request
           gh pr create \
             --repo actionutils/test-trusted-go-releaser \
-            --title "Test release for trusted-go-releaser PR #${{ github.event.pull_request.number }} ($COMMIT_SHORT_SHA)" \
-            --body "Automated test PR created from trusted-go-releaser PR #${{ github.event.pull_request.number }}
+            --title "Test release for trusted-go-releaser PR #${PR_NUMBER} (${SHA_SHORT})" \
+            --body "Automated test PR created from trusted-go-releaser PR #${PR_NUMBER}
 
-          **Source PR:** ${{ github.event.pull_request.html_url }}
-          **Source Ref:** https://github.com/actionutils/trusted-go-releaser/tree/$PR_HEAD_REF
-          **Source SHA:** https://github.com/actionutils/trusted-go-releaser/commit/${{ github.event.pull_request.head.sha }}
+          **Source:** ${PR_URL}
+          **Source Ref:** https://github.com/actionutils/trusted-go-releaser/tree/${HEAD_REF}
+          **Source SHA:** https://github.com/actionutils/trusted-go-releaser/commit/${SHA}
 
           This PR tests the trusted-go-releaser workflow." \
             --head "$FEATURE_BRANCH" \
@@ -88,8 +135,8 @@ jobs:
             --label "bump:patch"
 
           # Store PR number for later use
-          PR_NUMBER=$(gh pr list --repo actionutils/test-trusted-go-releaser --head "$FEATURE_BRANCH" --json number --jq '.[0].number')
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          TEST_PR_NUMBER=$(gh pr list --repo actionutils/test-trusted-go-releaser --head "$FEATURE_BRANCH" --json number --jq '.[0].number')
+          echo "TEST_PR_NUMBER=$TEST_PR_NUMBER" >> $GITHUB_ENV
 
       - name: Merge PR
         env:
@@ -99,12 +146,12 @@ jobs:
           sleep 5
 
           # Merge the PR directly
-          gh pr merge $PR_NUMBER \
+          gh pr merge $TEST_PR_NUMBER \
             --repo actionutils/test-trusted-go-releaser \
             --squash \
             --delete-branch
 
-          echo "PR #$PR_NUMBER merged successfully"
+          echo "PR #$TEST_PR_NUMBER merged successfully"
 
       - name: Wait for release workflow completion
         env:
@@ -160,18 +207,19 @@ jobs:
           echo "Reverted all base branch changes to restore original state"
 
       - name: Merge base branch to main
+        env:
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
+          PR_URL: ${{ steps.vars.outputs.pr_url }}
         run: |
           # Switch to main branch
           git checkout main
-
-          # Pull latest main
           git pull origin main
 
-          # Merge the base branch directly
-          git merge "$TEST_BASE_BRANCH" --no-ff -m "Merge test results back to main (PR #${{ github.event.pull_request.number }})
+          # Merge the base branch
+          git merge "$TEST_BASE_BRANCH" --no-ff -m "Merge test results back to main (PR #${PR_NUMBER})
 
-          Original test PR: https://github.com/actionutils/test-trusted-go-releaser/pull/$PR_NUMBER
-          Source trusted-go-releaser PR: ${{ github.event.pull_request.html_url }}
+          Original test PR: https://github.com/actionutils/test-trusted-go-releaser/pull/$TEST_PR_NUMBER
+          Source: ${PR_URL}
 
           This ensures tags created during testing are accessible from main branch via git tag --merged."
 
@@ -184,9 +232,11 @@ jobs:
           echo "Merged test base branch to main directly"
 
       - name: Output test PR info
+        env:
+          PR_NUMBER: ${{ steps.vars.outputs.pr_number }}
         run: |
           echo "✅ E2E test completed successfully!"
-          echo "Test PR URL: https://github.com/actionutils/test-trusted-go-releaser/pull/$PR_NUMBER"
+          echo "Test PR URL: https://github.com/actionutils/test-trusted-go-releaser/pull/$TEST_PR_NUMBER"
           echo "Base branch merged directly to main - no PR created"
           echo "Check the test repository for workflow execution and release creation."
           echo "Tags should now be trackable from main branch via 'git tag --merged'."


### PR DESCRIPTION
## Summary
- Skip automatic e2e test execution for PRs from forks (they don't have access to secrets)
- Add workflow_dispatch event for manual triggering with optional PR number and SHA inputs
- Auto-fetch PR information when only PR number is provided

## Changes
- Added condition to skip fork PRs: checks if `github.event.pull_request.head.repo.full_name == github.repository`
- Added `workflow_dispatch` event with optional `pr_number` and `sha` inputs
- Added automatic PR SHA fetching when only PR number is provided in workflow_dispatch
- Extracted event-specific variable setup into dedicated step
- Separated git configuration from other operations
- Replaced inline conditionals with environment variables
- Improved variable naming consistency

## How to test fork PRs
1. Fork PR will not trigger e2e tests automatically
2. Go to Actions tab → E2E Test workflow
3. Click "Run workflow"
4. Enter the PR number (SHA will be fetched automatically)
5. Or enter both PR number and specific SHA to test

## Testing
The workflow will now:
- Run automatically only for PRs from the same repository
- Be manually triggerable via Actions UI for fork PRs
- Automatically fetch PR information when only PR number is provided
- Handle both event types (pull_request and workflow_dispatch) correctly