### PR TITLE
fix: use github.event.pull_request.head.repo.fork for fork detection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
     # GitHub allows referencing commits from forks using @SHA in workflow references
     if: |
       (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
Improve fork PR detection by using the built-in boolean field instead of comparing repository names.

## Changes
- Replace `github.event.pull_request.head.repo.full_name == github.repository` with `!github.event.pull_request.head.repo.fork`
- This is more explicit and cleaner way to detect fork PRs

## Context
Follow-up to #22 - The previous PR was already merged, but this improvement makes the fork detection more idiomatic.

The `github.event.pull_request.head.repo.fork` is a boolean field that GitHub provides specifically for detecting if a PR comes from a forked repository.