### PR TITLE
fix: use github.event.repository.fork for more reliable fork detection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,9 +21,10 @@ jobs:
     # Skip for fork PRs when triggered by pull_request event (no access to secrets)
     # For fork PRs, use workflow_dispatch with the fork's commit SHA to test manually
     # GitHub allows referencing commits from forks using @SHA in workflow references
+    # Using github.event.repository.fork to check if current repo context is a fork
     if: |
       (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+      (github.event_name == 'pull_request' && github.event.repository.fork != true)
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
Improve fork detection by using `github.event.repository.fork != true` instead of `!github.event.pull_request.head.repo.fork`.

## Why this change?
According to [this article](https://beckysweger.com/2025/01/02/skip-a-job-in-a.html), `github.event.repository.fork` is more reliable for detecting if a workflow is running in a fork context. It checks the repository where the workflow is executing, rather than checking the PR source repository.

## Changes
- Replace `!github.event.pull_request.head.repo.fork` with `github.event.repository.fork != true`
- Added comment explaining the fork detection approach

## Context
This is a follow-up improvement after #23 was merged. The new approach is more consistent and reliable across different scenarios.