### PR TITLE
ci: add actionlint workflow for GitHub Actions linting

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,25 @@
+name: actionlint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: reviewdog/action-actionlint@v1.67.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_on_error: true


### PR DESCRIPTION
## Summary
- Add reviewdog/action-actionlint@v1.67.0 workflow for linting GitHub Actions
- Configure to run on pull requests and pushes to main branch
- Use actions/checkout@v5 for checking out code

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Check that actionlint reports are posted as PR reviews
- [ ] Confirm workflow fails on errors as expected

🤖 Generated with [Claude Code](https://claude.ai/code)