### PR TITLE
workflow: sign binstaller scripts with cosign + tighten verification

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -168,8 +168,6 @@ jobs:
           binst gen --type=runner --target-version='${{ needs.version.outputs.tag_name }}' --output=./dist/run.sh
       - name: Sign installer and runner with cosign
         if: steps.check-config.outputs.config_exists == 'true'
-        env:
-          COSIGN_EXPERIMENTAL: 'true'
         run: |
           cosign sign-blob \
             --yes \


### PR DESCRIPTION
This PR:

- Signs binstaller-generated install.sh and run.sh via cosign (keyless).
- Uploads .sig and .pem alongside scripts in release assets.
- Adds CI verification of script signatures after release.
- Tightens cosign verification identity to this repo's workflow:
  - ^https://github.com/actionutils/trusted-go-releaser/.github/workflows/trusted-release-workflow.yml@.*$
- Extends release notes with cosign verification examples for scripts.

Notes:
- Uses OIDC keyless signing; no secrets required.  is already enabled.
- Cosign installed via sigstore/cosign-installer in the workflow.
