### PR TITLE
Update trusted-tag-verifier usage to unified format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Verify Trusted Tag Releaser
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          repository: 'actionutils/trusted-tag-releaser'
-          tag: 'v0'
+          verify: 'actionutils/trusted-tag-releaser@v0'
 
   # Post version bump information comment on PR when labeled
   release-preview-comment:
@@ -81,4 +80,3 @@ jobs:
     uses: actionutils/trusted-tag-releaser/.github/workflows/trusted-release-workflow.yml@v0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
## Summary
- Update workflow to use the new unified verify parameter format

## Changes
- Replace `repository` and `tag` inputs with `verify` input using format `<owner>/<repo>@<version>`

## Related
- Depends on actionutils/trusted-tag-verifier#11

🤖 Generated with [Claude Code](https://claude.ai/code)