### PR TITLE
Improve E2E test visibility and error handling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,10 +229,11 @@ jobs:
 
           if [ -n "$LATEST_RUN_ID" ] && [ "$LATEST_RUN_ID" != "null" ]; then
             echo "Found release workflow run: $LATEST_RUN_ID"
+            echo "Workflow URL: https://github.com/actionutils/test-trusted-go-releaser/actions/runs/$LATEST_RUN_ID"
             echo "Watching workflow progress..."
 
             # Watch the workflow run until completion
-            gh run watch "$LATEST_RUN_ID" --repo actionutils/test-trusted-go-releaser
+            gh run watch "$LATEST_RUN_ID" --compact --exit-status --repo actionutils/test-trusted-go-releaser
 
             echo "✅ Release workflow completed!"
           else


### PR DESCRIPTION
## Summary
- Display GitHub Actions workflow URL before watching to improve visibility during E2E test execution
- Add `--compact` and `--exit-status` flags to `gh run watch` command for better error handling and output

## Changes
- Added workflow URL output before starting to watch the release workflow run
- Added `--compact` flag for more concise output
- Added `--exit-status` flag to ensure the E2E test fails properly if the watched workflow fails

## Reference
This applies the same improvements made to the trusted-tag-releaser repository:
- actionutils/trusted-tag-releaser#76

🤖 Generated with [Claude Code](https://claude.ai/code)