### PR TITLE
Add mingw dlltool installation support for Windows GNU builds

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: 'go.mod'
+      install-mingw-dlltool:
+        description: 'Whether to install mingw binutils (dlltool) for Windows GNU builds'
+        required: false
+        type: boolean
+        default: false
       environment:
         description: 'Environment for protecting the release flow'
         required: false
@@ -287,6 +292,11 @@ jobs:
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
         with:
           version: ${{ inputs.zig-version }}
+
+      # Provide dlltool for windows-gnu without hijacking cc/c++
+      - name: Install mingw binutils (dlltool)
+        if: inputs.install-mingw-dlltool
+        run: sudo apt-get update && sudo apt-get install -y binutils-mingw-w64
 
       - uses: sigstore/cosign-installer@v3.9.2 # installs cosign
       - uses: anchore/sbom-action/download-syft@v0.20.5 # installs syft


### PR DESCRIPTION
## Summary
- Add new `install-mingw-dlltool` input to the trusted release workflow
- Install `binutils-mingw-w64` package when the input is set to true
- Provides dlltool for Windows GNU cross-compilation without hijacking cc/c++ toolchain

## Details
This PR adds support for installing mingw binutils (specifically dlltool) which is needed for certain Windows GNU cross-compilation scenarios. The installation step is placed after Zig setup and before cosign installation in the goreleaser job.

The new input `install-mingw-dlltool` is optional and defaults to `false`, ensuring backward compatibility.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with `install-mingw-dlltool: false` (default) - should work as before
- [ ] Test with `install-mingw-dlltool: true` - should install binutils-mingw-w64

🤖 Generated with [Claude Code](https://claude.ai/code)