### PR TITLE
feat: add support for passing dynamic secrets to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,5 +70,3 @@ jobs:
       environment: release
       semver-tags-environment: release-semver-tags
       release-notes: ${{ fromJSON(needs.release-pr.outputs.release_pr).release_notes }}
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -422,16 +422,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create base environment JSON with GITHUB_TOKEN
-          BASE_ENV="{\"GITHUB_TOKEN\": \"${GITHUB_TOKEN}\"}"
+          BASE_ENV='{"GITHUB_TOKEN": "'${GITHUB_TOKEN}'"}'
 
           # Merge with additional environment variables if provided
           if [[ -n "${GORELEASER_ENV_JSON}" ]]; then
             # Merge the two JSON objects, with GORELEASER_ENV_JSON taking precedence
-            MERGED_ENV=$(echo "${BASE_ENV}" | jq -s --argjson custom "${GORELEASER_ENV_JSON}" '.[0] * $custom')
-            echo "env_json=${MERGED_ENV}" >> "$GITHUB_OUTPUT"
+            MERGED_ENV=$(jq -sc '.[0] * .[1]' <(echo "$BASE_ENV") <(echo "$GORELEASER_ENV_JSON"))
           else
-            echo "env_json=${BASE_ENV}" >> "$GITHUB_OUTPUT"
+            MERGED_ENV=$(echo "$BASE_ENV" | jq -c '.')
           fi
+          echo "env_json=${MERGED_ENV}" >> "$GITHUB_OUTPUT"
 
       - uses: goreleaser/goreleaser-action@v6 # run goreleaser
         id: goreleaser

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -50,6 +50,9 @@ on:
         required: false
         type: string
     secrets:
+      github-token:
+        description: 'DEPRECATED: This input is deprecated and will be removed in a future version. The workflow uses secrets.GITHUB_TOKEN automatically.'
+        required: false
       goreleaser-env-json:
         description: 'JSON object of environment variables to pass to goreleaser (e.g., {"HOMEBREW_TAP_GITHUB_TOKEN": "..."})'
         required: false
@@ -80,6 +83,11 @@ jobs:
       message: ${{ steps.bumpr-dry-run.outputs.message }}
       temp_branch: ${{ steps.create-temp-branch.outputs.temp_branch }}
     steps:
+      - name: Check for deprecated inputs
+        if: secrets.github-token != ''
+        run: |
+          echo "::warning::The 'github-token' secret input is deprecated and will be removed in a future version. The workflow now uses secrets.GITHUB_TOKEN automatically. Please remove the 'github-token' input from your workflow."
+
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -84,7 +84,9 @@ jobs:
       temp_branch: ${{ steps.create-temp-branch.outputs.temp_branch }}
     steps:
       - name: Check for deprecated inputs
-        if: secrets.github-token != ''
+        env:
+          DEPRECATED_TOKEN: ${{ secrets.github-token }}
+        if: env.DEPRECATED_TOKEN != ''
         run: |
           echo "::warning::The 'github-token' secret input is deprecated and will be removed in a future version. The workflow now uses secrets.GITHUB_TOKEN automatically. Please remove the 'github-token' input from your workflow."
 

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -129,7 +129,7 @@ jobs:
         id: create-temp-branch
         if: steps.bumpr-dry-run.outputs.skip != 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_VERSION: ${{ steps.bumpr-dry-run.outputs.next_version }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
@@ -160,7 +160,7 @@ jobs:
       # Add release information to job summary
       - name: Add release information to job summary
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_RELEASE_NOTES: ${{ inputs.release-notes }}
           SKIP_RELEASE: ${{ steps.bumpr-dry-run.outputs.skip }}
           NEXT_VERSION: ${{ steps.bumpr-dry-run.outputs.next_version }}
@@ -409,10 +409,9 @@ jobs:
         id: goreleaser-env
         env:
           GORELEASER_ENV_JSON: ${{ secrets.goreleaser-env-json }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create base environment JSON with GITHUB_TOKEN
-          # Note: Using github.token (default) for goreleaser to ensure OIDC signing works
           BASE_ENV="{\"GITHUB_TOKEN\": \"${GITHUB_TOKEN}\"}"
 
           # Merge with additional environment variables if provided
@@ -497,7 +496,7 @@ jobs:
       - name: Upload installer and runner to release
         if: steps.check-config.outputs.config_exists == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.version.outputs.tag_name }}
         run: |
           gh release upload "${VERSION}" \
@@ -724,7 +723,7 @@ jobs:
       - name: Update GitHub Release
         id: update_release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_RELEASE_NOTES: ${{ inputs.release-notes }}
           TAG_NAME: ${{ needs.version.outputs.tag_name }}
           INSTRUCTIONS_FILE: ${{ steps.add_binstaller_instructions.outputs.instructions_file }}
@@ -772,7 +771,7 @@ jobs:
 
       - name: Download assets
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.version.outputs.tag_name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
@@ -839,7 +838,7 @@ jobs:
       # See: https://github.com/orgs/community/discussions/151442
       - name: Delete temporary branch
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEMP_BRANCH: ${{ needs.release-check.outputs.temp_branch }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -53,6 +53,9 @@ on:
       github-token:
         description: 'GitHub token with appropriate permissions'
         required: true
+      goreleaser-env-json:
+        description: 'JSON object of environment variables to pass to goreleaser (e.g., {"HOMEBREW_TAP_GITHUB_TOKEN": "..."})'
+        required: false
     outputs:
       tag_name:
         description: 'The tag name created or used for this release'
@@ -404,13 +407,31 @@ jobs:
           echo "$CUSTOM_RELEASE_NOTES" > "$NOTES_FILE"
           echo "file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
+      # Prepare environment variables for goreleaser
+      - name: Prepare goreleaser environment
+        id: goreleaser-env
+        env:
+          GORELEASER_ENV_JSON: ${{ secrets.goreleaser-env-json }}
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+        run: |
+          # Create base environment JSON with GITHUB_TOKEN
+          BASE_ENV="{\"GITHUB_TOKEN\": \"${GITHUB_TOKEN}\"}"
+
+          # Merge with additional environment variables if provided
+          if [[ -n "${GORELEASER_ENV_JSON}" ]]; then
+            # Merge the two JSON objects, with GORELEASER_ENV_JSON taking precedence
+            MERGED_ENV=$(echo "${BASE_ENV}" | jq -s --argjson custom "${GORELEASER_ENV_JSON}" '.[0] * $custom')
+            echo "env_json=${MERGED_ENV}" >> "$GITHUB_OUTPUT"
+          else
+            echo "env_json=${BASE_ENV}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: goreleaser/goreleaser-action@v6 # run goreleaser
         id: goreleaser
         with:
           version: '~> v2'
           args: release --clean --draft${{ steps.custom-release-notes.outputs.file && format(' --release-notes {0}', steps.custom-release-notes.outputs.file) || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env: ${{ fromJSON(steps.goreleaser-env.outputs.env_json) }}
       - name: Get checksum file name
         id: checksumtxt
         env:

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -50,9 +50,6 @@ on:
         required: false
         type: string
     secrets:
-      github-token:
-        description: 'GitHub token with appropriate permissions'
-        required: true
       goreleaser-env-json:
         description: 'JSON object of environment variables to pass to goreleaser (e.g., {"HOMEBREW_TAP_GITHUB_TOKEN": "..."})'
         required: false
@@ -132,7 +129,7 @@ jobs:
         id: create-temp-branch
         if: steps.bumpr-dry-run.outputs.skip != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           NEXT_VERSION: ${{ steps.bumpr-dry-run.outputs.next_version }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
@@ -412,9 +409,10 @@ jobs:
         id: goreleaser-env
         env:
           GORELEASER_ENV_JSON: ${{ secrets.goreleaser-env-json }}
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Create base environment JSON with GITHUB_TOKEN
+          # Note: Using github.token (default) for goreleaser to ensure OIDC signing works
           BASE_ENV="{\"GITHUB_TOKEN\": \"${GITHUB_TOKEN}\"}"
 
           # Merge with additional environment variables if provided
@@ -499,7 +497,7 @@ jobs:
       - name: Upload installer and runner to release
         if: steps.check-config.outputs.config_exists == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.version.outputs.tag_name }}
         run: |
           gh release upload "${VERSION}" \
@@ -726,7 +724,7 @@ jobs:
       - name: Update GitHub Release
         id: update_release
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ github.token }}
           CUSTOM_RELEASE_NOTES: ${{ inputs.release-notes }}
           TAG_NAME: ${{ needs.version.outputs.tag_name }}
           INSTRUCTIONS_FILE: ${{ steps.add_binstaller_instructions.outputs.instructions_file }}
@@ -841,7 +839,7 @@ jobs:
       # See: https://github.com/orgs/community/discussions/151442
       - name: Delete temporary branch
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ github.token }}
           TEMP_BRANCH: ${{ needs.release-check.outputs.temp_branch }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Summary
- Add `goreleaser-env-json` secret input for passing dynamic environment variables to goreleaser
- Deprecate `secrets.github-token` input (kept for backward compatibility with warning)
- Consistently use `secrets.GITHUB_TOKEN` throughout the workflow
- Enable support for Homebrew tap, Fury.io, AUR, and other goreleaser features requiring additional tokens

## Changes
1. **New secret input**: `goreleaser-env-json` - accepts JSON object with environment variables
2. **Deprecated input**: `github-token` - shows warning when used, will be removed in future major version
3. **Token consistency**: All operations now use `secrets.GITHUB_TOKEN` for better clarity

## Migration Guide
If you're currently using `github-token`:
```yaml
# Old (deprecated)
secrets:
  github-token: ${{ secrets.MY_TOKEN }}

# New (just remove it)
# The workflow automatically uses secrets.GITHUB_TOKEN
```

## Test plan
- [ ] Test with a project that uses Homebrew tap publishing
- [ ] Verify OIDC signing (cosign, gitsign) still works correctly
- [ ] Confirm existing releases without `goreleaser-env-json` continue to work
- [ ] Test with `goreleaser-env-json` containing multiple environment variables
- [ ] Verify deprecation warning appears when using `github-token` input

🤖 Generated with [Claude Code](https://claude.ai/code)